### PR TITLE
Change colors

### DIFF
--- a/src/components/Cell.js
+++ b/src/components/Cell.js
@@ -8,14 +8,17 @@ class Cell extends Component{
   }
 
   render() {
-    let cell;
-    this.props.filled ? (cell = this.props.score) 
-    : (cell = this.props.potential)
+    let score = this.props.filled ? this.props.score : this.props.potential
+    let className = this.props.filled ? "filled" : (this.props.active ? "active" : "empty")
     
     return (
-      <td className={`cell ${this.props.filled ? "filled" : 
-          (this.props.active ? "active" : "empty")}`} 
-          onClick={this.cellClick}>{cell}</td>
+      <td className={`score-cell ${className}`}>
+        <div className={`score ${className}`}
+            onClick={this.cellClick}
+        >
+          {score}
+        </div>
+      </td>
     )
   }
 }

--- a/src/styles/Cell.css
+++ b/src/styles/Cell.css
@@ -1,19 +1,22 @@
-.filled {
+.score.filled {
   color: blue;
 }
-.active {
+.score.active {
   color: red;
-  border: 1px solid red;
   cursor: pointer;
 }
-.empty {
-  color: #FFFE90;
+.score.empty {
   cursor: pointer;
+  opacity: 0;
 }
-.incomplete {
-  color: #FFFE90;
+.score.incomplete {
   cursor: default; 
 }
-.gray {
+.score.gray {
   color: #666;
+}
+
+
+.score-cell.active {
+	border: 1px solid red;
 }

--- a/src/styles/DiceContainer.css
+++ b/src/styles/DiceContainer.css
@@ -1,5 +1,5 @@
 body {
-	background: #80D0FF;
+	background: oldlace;
 }
 .app-container {
 	display: flex;
@@ -27,7 +27,7 @@ body {
 	margin: .5em;
 }
 .dice-bar > .free {
-	border: 10px solid #FFFE90;
+	border: 10px solid moccasin;
 }
 .dice-bar > .hold {
 	border: 10px solid #F00;
@@ -50,7 +50,7 @@ body {
 	margin: 15px;
 }
 .roll-canvas {
-	background-color: #FFFE90;	
+	background-color: moccasin;
 	cursor: default;
 	box-shadow: -6px 6px 2px #888;
 	display: flex;
@@ -78,7 +78,7 @@ body {
 	width: 130px;
 	height: 130px;
 	cursor: pointer;
-	border: 10px solid #FFFE90;;
+	border: 10px solid moccasin;
 }
 .reroll {
 	border: 10px solid #F00;

--- a/src/styles/ScoreTable.css
+++ b/src/styles/ScoreTable.css
@@ -12,12 +12,12 @@ td {
 .scorecard-canvas {
 	display: flex;
 	padding: 4px;
-	background: #FFFE90;
+	background: moccasin;
 	border-radius: 10px;
 	box-shadow: -4px 4px 2px #555;
 }
 .modal-div {
-	background: #FFFE90;
+	background: moccasin;
 	border-radius: 10px;
 	border: 2px solid #777;
 	font-size: 1.5rem;


### PR DESCRIPTION
This PR adds a `div` to the cell component so that I can control the border styling and the text styling independently.  It uses `opacity: 0` to hide the text in empty cells but allow them to still be clickable.  And it chooses some different colors for the app, which will hopefully show up better on a variety of screens.

Fixes #13 